### PR TITLE
un-enforce_available_locales before loading language files, or else you get deprication warnings

### DIFF
--- a/lib/responsys_api.rb
+++ b/lib/responsys_api.rb
@@ -1,8 +1,8 @@
 require "i18n"
 
+I18n.enforce_available_locales = false
 I18n.load_path << File.expand_path("../responsys/i18n/en.yml", __FILE__)
 I18n.locale = :en
-I18n.enforce_available_locales = false
 
 require "responsys/exceptions/all"
 require "responsys/helper"


### PR DESCRIPTION
```
> bundle exec rails c
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
Loading development environment (Rails 4.0.3)
irb(main):001:0>
```

Disabling the locale enforcement first fixes this. 
