### PR TITLE
Update gem dependancies so that it can be used in a Rails 4.2.1 project

### DIFF
--- a/responsys-api.gemspec
+++ b/responsys-api.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency "rubyntlm", "0.4.0"
-  spec.add_dependency "savon", "2.6.0"
-  spec.add_dependency "wasabi", "3.3.0"
-  spec.add_dependency "i18n", "~> 0.6.9"
-  spec.add_dependency "connection_pool", "2.0.0"
+  spec.add_dependency "savon", "2.10.1"
+  spec.add_dependency "wasabi", "3.4.0"
+  spec.add_dependency "i18n", "~> 0.7"
+  spec.add_dependency "connection_pool", "2.1.3"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.3"
-  spec.add_development_dependency "rspec", "~> 3.1.0"
-  spec.add_development_dependency "vcr", "~> 2.9.3"
+  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "vcr", "~> 2.9"
   spec.add_development_dependency "webmock", "~> 1.9"
 end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -16,7 +16,12 @@ describe Responsys::Helper do
     end
 
     it "should get the default locale message if locale is not present" do
-      I18n.locale = :not_available_locale
+      begin
+        I18n.locale = :not_available_locale
+      rescue I18n::InvalidLocale
+      end
+
+      expect(I18n.locale).to eq(:en)
       expect(Responsys::Helper.get_message(message_key))
         .to eq("The member has not been found in the list")
     end


### PR DESCRIPTION
i18n gem needed to be updated as activesupport (4.2.1) depends on i18n (~> 0.7) and responsys-api was using i18n (~> 0.6.9).

Had to modify test for none existent local as i18n now throws exception for invalid local.

Other gems updated

"savon", "2.6.0" to "2.10.1"
"wasabi", "3.3.0" to "3.4.0"
"connection_pool", "2.0.0" to "2.1.3"
