### PR TITLE
Configuration refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.1.2
 gemfile:
   - Gemfile
+before_install:
+  - gem uninstall bundler
+  - gem install bundler -v 1.11.2
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 gemfile:
   - Gemfile
 before_install:
-  - gem uninstall bundler
   - gem install bundler -v 1.11.2
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A gem to help you communicate to the Responsys Interact SOAP API. Currently working of Responsys Interact version 6.20.
 
+:warning: The REST version of the GEM is available on a [WIP branch](https://github.com/dandemeyere/responsys-api/tree/migration-to-rest-apis)
+
 ## Documentation
 
 Have a look at our [wiki](https://github.com/dandemeyere/responsys-api/wiki) to understand the functionality this gem offers, how  to use it, and some tips to help you avoid the same mistakes we ran into! If you have any questions or if you want to report a bug please create an [issue](https://github.com/dandemeyere/responsys-api/issues).
@@ -27,12 +29,14 @@ Responsys.configure do |config|
     password: "your_responsys_password",
     wsdl: "https://wsXXXX.responsys.net/webservices/wsdl/ResponsysWS_Level1.wsdl",
     debug: false,
-    ssl_version: :TLSv1
+    enabled: true,
+    savon_settings: { # Any Savon 2 settings, below are the default options
+      ssl_version: :TLSv1,
+      element_form_default: :qualified
+    }
   }
 end
 ```
-
-Note that the debug option is optional and is set to false by default.
 
 ### Example
 ```ruby

--- a/lib/responsys/api/campaign.rb
+++ b/lib/responsys/api/campaign.rb
@@ -6,8 +6,8 @@ module Responsys
       include Responsys::Exceptions
 
       def trigger_custom_event(custom_event, recipients)
-        raise ParameterException, Responsys::Helper.get_message("api.campaign.incorrect_recipients_type") unless recipients.is_a? Array
-        raise ParameterException, Responsys::Helper.get_message("api.object.custom_event.incorrect_event_object") unless custom_event.is_a? Responsys::Api::Object::CustomEvent
+        raise ParameterException.new("api.campaign.incorrect_recipients_type") unless recipients.is_a? Array
+        raise ParameterException.new("api.object.custom_event.incorrect_event_object") unless custom_event.is_a? Responsys::Api::Object::CustomEvent
 
         message = {
           customEvent: custom_event.to_api,
@@ -17,7 +17,7 @@ module Responsys
       end
 
       def trigger_message(campaign, recipients)
-        raise ParameterException, Responsys::Helper.get_message("api.campaign.incorrect_recipients_type") unless recipients.is_a? Array
+        raise ParameterException.new("api.campaign.incorrect_recipients_type") unless recipients.is_a? Array
         message = {
           campaign: campaign.to_api,
           recipientData: recipients.map(&:to_api)

--- a/lib/responsys/api/client.rb
+++ b/lib/responsys/api/client.rb
@@ -15,7 +15,7 @@ module Responsys
       end
 
       def api_method(action, message = nil, response_type = :hash)
-        raise GenericException.new("api.client.api_method.wrong_action_#{action.to_s}") if action.to_sym == :login || action.to_sym == :logout
+        raise ParameterException.new("api.client.api_method.wrong_action_#{action.to_s}") if action.to_sym == :login || action.to_sym == :logout
 
         unless Responsys.configuration.enabled?
           raise DisabledException.new if @raise_exceptions
@@ -47,7 +47,7 @@ module Responsys
         begin
           yield(self)
         rescue DisabledException => e
-          raise e if exception_raising
+          raise e if @raise_exceptions
           return "disabled"
         ensure
           @raise_exceptions = old_raise_exceptions

--- a/lib/responsys/api/client.rb
+++ b/lib/responsys/api/client.rb
@@ -41,6 +41,7 @@ module Responsys
         end
       end
 
+      # For internal use ONLY
       def run(exception_raising = false)
         old_raise_exceptions = @raise_exceptions
         @raise_exceptions = exception_raising

--- a/lib/responsys/api/client.rb
+++ b/lib/responsys/api/client.rb
@@ -2,6 +2,7 @@ module Responsys
   module Api
     class Client
       include Responsys::Api::All
+      include Responsys::Exceptions
       attr_accessor :client
 
       #TODO allows to keep the use of .instance. The client is no longer a singleton so it needs to be removed in a newer release.
@@ -10,7 +11,7 @@ module Responsys
       end
 
       def api_method(action, message = nil, response_type = :hash)
-        raise Responsys::Helper.get_message("api.client.api_method.wrong_action_#{action.to_s}") if action.to_sym == :login || action.to_sym == :logout
+        raise GenericException.new("api.client.api_method.wrong_action_#{action.to_s}") if action.to_sym == :login || action.to_sym == :logout
 
         SessionPool.instance.with do |session|
           begin

--- a/lib/responsys/api/client.rb
+++ b/lib/responsys/api/client.rb
@@ -10,8 +10,17 @@ module Responsys
         alias :instance :new
       end
 
+      def initialize
+        @raise_exceptions = false
+      end
+
       def api_method(action, message = nil, response_type = :hash)
         raise GenericException.new("api.client.api_method.wrong_action_#{action.to_s}") if action.to_sym == :login || action.to_sym == :logout
+
+        unless Responsys.configuration.enabled?
+          raise DisabledException.new if @raise_exceptions
+          return "disabled"
+        end
 
         SessionPool.instance.with do |session|
           begin
@@ -29,6 +38,19 @@ module Responsys
           rescue Exception => e
             Responsys::Helper.format_response_with_errors(e)
           end
+        end
+      end
+
+      def run(exception_raising = false)
+        old_raise_exceptions = @raise_exceptions
+        @raise_exceptions = exception_raising
+        begin
+          yield(self)
+        rescue DisabledException => e
+          raise e if exception_raising
+          return "disabled"
+        ensure
+          @raise_exceptions = old_raise_exceptions
         end
       end
 

--- a/lib/responsys/api/list.rb
+++ b/lib/responsys/api/list.rb
@@ -4,6 +4,7 @@ module Responsys
   module Api
     module List
       include Responsys::Api::Object
+
       def retrieve_list_members(interact_object, query_column, field_list, ids_to_retrieve)
         message = {
           list: interact_object.to_api,

--- a/lib/responsys/api/list.rb
+++ b/lib/responsys/api/list.rb
@@ -15,24 +15,19 @@ module Responsys
         api_method(:retrieve_list_members, message)
       end
 
-      def merge_list_members(interact_object, record_data, merge_rule = ListMergeRule.new)
+      def merge_list_members(interact_object, record_data, merge_rule = ListMergeRule.new, riid = false)
         message = {
           list: interact_object.to_api,
           recordData: record_data.to_api,
           mergeRule: merge_rule.to_api
         }
 
-        api_method(:merge_list_members, message)
+        method_name = riid ? "merge_list_members_riid" : "merge_list_members"
+        api_method(method_name.to_sym, message)
       end
 
       def merge_list_members_riid(interact_object, record_data, merge_rule = ListMergeRule.new)
-        message = {
-          list: interact_object.to_api,
-          recordData: record_data.to_api,
-          mergeRule: merge_rule.to_api
-        }
-
-        api_method(:merge_list_members_riid, message)
+        merge_list_members(interact_object, record_data, merge_rule, true)
       end
     end
   end

--- a/lib/responsys/api/object/custom_event.rb
+++ b/lib/responsys/api/object/custom_event.rb
@@ -6,7 +6,7 @@ module Responsys
         attr_accessor :event_name, :event_id, :event_string_data_mapping, :event_number_data_mapping, :event_date_data_mapping
 
         def initialize(event_name="", event_id="", options={})
-          raise ParameterException, Responsys::Helper.get_message("api.object.custom_event.empty_event") if event_name.blank? && event_id.blank?
+          raise ParameterException.new("api.object.custom_event.empty_event") if event_name.blank? && event_id.blank?
           @event_name = event_name || ""
           @event_id = event_id || ""
           @event_string_data_mapping = options[:event_string_data_mapping] || ""

--- a/lib/responsys/api/object/record_data.rb
+++ b/lib/responsys/api/object/record_data.rb
@@ -7,7 +7,7 @@ module Responsys
         attr_accessor :field_names, :records
 
         def initialize(data)
-          raise ParameterException, Responsys::Helper.get_message("api.object.record_data.incorrect_record_data_type") unless data.is_a? Array
+          raise ParameterException.new("api.object.record_data.incorrect_record_data_type") unless data.is_a? Array
 
           self.field_names = data.map { |record| record.keys }.flatten.uniq
 

--- a/lib/responsys/api/session.rb
+++ b/lib/responsys/api/session.rb
@@ -5,19 +5,10 @@ module Responsys
       include Responsys::Api::Authentication
 
       def initialize
-        settings = Responsys.configuration.settings
-        @credentials = {
-          username: settings[:username],
-          password: settings[:password]
-        }
+        global_configuration = Responsys::configuration
 
-        ssl_version = settings[:ssl_version] || :TLSv1
-
-        if settings[:debug]
-          @savon_client = Savon.client(wsdl: settings[:wsdl], element_form_default: :qualified, ssl_version: ssl_version, log_level: :debug, log: true, pretty_print_xml: true)
-        else
-          @savon_client = Savon.client(wsdl: settings[:wsdl], element_form_default: :qualified, ssl_version: ssl_version)
-        end
+        @credentials = global_configuration.api_credentials
+        @savon_client = Savon.client(global_configuration.savon_settings)
       end
 
       def run(method, message)

--- a/lib/responsys/api/session.rb
+++ b/lib/responsys/api/session.rb
@@ -5,7 +5,7 @@ module Responsys
       include Responsys::Api::Authentication
 
       def initialize
-        global_configuration = Responsys::configuration
+        global_configuration = Responsys.configuration
 
         @credentials = global_configuration.api_credentials
         @savon_client = Savon.client(global_configuration.savon_settings)

--- a/lib/responsys/configuration.rb
+++ b/lib/responsys/configuration.rb
@@ -33,6 +33,10 @@ module Responsys
     def debug?
       !!(@settings[:debug])
     end
+
+    def enabled?
+      !!(@settings[:enabled])
+    end
   end
 
   class << self
@@ -44,8 +48,6 @@ module Responsys
   end
 
   def self.configure
-    @configuration = nil
-
     yield(configuration)
 
     check_configuration
@@ -104,6 +106,7 @@ module Responsys
 
   def self.default_settings_hash
     {
+      enabled: true,
       debug: false,
       sessions: {
         size: 80,

--- a/lib/responsys/configuration.rb
+++ b/lib/responsys/configuration.rb
@@ -7,7 +7,7 @@ module Responsys
     end
 
     def savon_settings
-      settings_hash = if !@settings[:wsdl].blank?
+      settings_hash = if @settings[:wsdl].present?
         { wsdl: @settings[:wsdl] }
       else
         {
@@ -89,9 +89,9 @@ module Responsys
   end
 
   def self.absent_api_description?
-    wsdl = !@configuration.settings[:wsdl].blank?
-    endpoint = !@configuration.settings[:endpoint].blank?
-    namespace = !@configuration.settings[:namespace].blank?
+    wsdl = @configuration.settings[:wsdl].present?
+    endpoint = @configuration.settings[:endpoint].present?
+    namespace = @configuration.settings[:namespace].present?
 
     return false if wsdl
 

--- a/lib/responsys/configuration.rb
+++ b/lib/responsys/configuration.rb
@@ -1,18 +1,65 @@
 module Responsys
   class Configuration
+    include Responsys::Exceptions
+
     attr_accessor :settings
 
     def initialize
-      @settings = {
-        username: nil,
-        password: nil,
-        wsdl: "",
-        debug: false,
-        sessions: {
-          size: 80,
-          timeout: 30
-        }
+      @settings = {}
+    end
+
+    def savon_settings
+      raise GenericException.new("A WSDL or endpoint is needed.") if absent_api_description?
+
+      default_savon_settings
+        .merge!(@settings[:savon_settings])
+        .merge!(savon_api_description)
+    end
+
+    def api_credentials
+      {
+        username: @settings[:username],
+        password: @settings[:password]
       }
+    end
+
+    def savon_api_description
+      if !@settings[:wsdl].blank?
+        { wsdl: @settings[:wsdl] }
+      else
+        {
+          endpoint: @settings[:endpoint],
+          namespace: @settings[:namespace]
+        }
+      end
+    end
+
+    private
+
+    def absent_api_description?
+      wsdl = !@settings[:wsdl].blank?
+      endpoint = !@settings[:endpoint].blank?
+      namespace = !@settings[:namespace].blank?
+
+      return false if wsdl
+
+      return !(endpoint && namespace) if endpoint || namespace
+
+      true
+    end
+
+    def default_savon_settings
+      settings = { ssl_version: :TLSv1, element_form_default: :qualified }
+
+      if @settings[:debug]
+        settings.merge!(savon_debug_settings)
+      else
+        settings
+      end
+    end
+
+    def savon_debug_settings
+      { log_level: :debug, log: true, pretty_print_xml: true }
     end
   end
 
@@ -26,6 +73,22 @@ module Responsys
 
   def self.configure
     yield(configuration)
+
+    @configuration.settings.merge!(default_settings_hash)
+
     Responsys::Api::SessionPool.init
+  end
+
+  private
+
+  def self.default_settings_hash
+    {
+      debug: false,
+      sessions: {
+        size: 80,
+        timeout: 30
+      },
+      savon_settings: {}
+    }
   end
 end

--- a/lib/responsys/exceptions.rb
+++ b/lib/responsys/exceptions.rb
@@ -1,0 +1,19 @@
+module Responsys
+  module Exceptions
+    class BaseException < Exception
+      def initialize(message_key = nil)
+        if message_key.nil?
+          super
+        else
+          super(Responsys::Helper.get_message(message_key))
+        end
+      end
+    end
+
+    class ParameterException < Responsys::Exceptions::BaseException
+    end
+
+    class GenericException < Responsys::Exceptions::BaseException
+    end
+  end
+end

--- a/lib/responsys/exceptions.rb
+++ b/lib/responsys/exceptions.rb
@@ -13,6 +13,12 @@ module Responsys
     class ParameterException < Responsys::Exceptions::BaseException
     end
 
+    class DisabledException < Responsys::Exceptions::BaseException
+      def initialize
+        super("gem_is_disabled")
+      end
+    end
+
     class GenericException < Responsys::Exceptions::BaseException
     end
   end

--- a/lib/responsys/exceptions/all.rb
+++ b/lib/responsys/exceptions/all.rb
@@ -1,1 +1,0 @@
-require "responsys/exceptions/parameter_exception"

--- a/lib/responsys/exceptions/parameter_exception.rb
+++ b/lib/responsys/exceptions/parameter_exception.rb
@@ -1,7 +1,0 @@
-module Responsys
-  module Exceptions
-    class ParameterException < Exception
-    end
-  end
-end
-

--- a/lib/responsys/i18n/en.yml
+++ b/lib/responsys/i18n/en.yml
@@ -18,41 +18,6 @@ en:
           empty_event: The event_name or event_id must be specified
           incorrect_event_object: "custom_event must be a CustomEvent instance"
       client:
-        available_methods:
-          - wsdl
-          - endpoint
-          - namespace
-          - raise_errors
-          - proxy
-          - headers
-          - open_timeout
-          - read_timeout
-          - ssl_verify_mode
-          - ssl_version
-          - ssl_cert_file
-          - ssl_cert_key_file
-          - ssl_ca_cert_file
-          - ssl_cert_key_password
-          - convert_request_keys_to
-          - soap_header
-          - element_form_default
-          - env_namespace
-          - namespace_identifier
-          - namespaces
-          - encoding
-          - soap_version
-          - basic_auth
-          - digest_auth
-          - wsse_auth
-          - wsse_timestamp
-          - ntlm
-          - strip_namespaces
-          - convert_response_tags_to
-          - logger
-          - log_level
-          - log
-          - filters
-          - pretty_print_xml
         api_method:
           wrong_action_login: Please use the dedicated login method
           wrong_action_logout: Please use the dedicated logout method

--- a/lib/responsys/i18n/en.yml
+++ b/lib/responsys/i18n/en.yml
@@ -1,5 +1,8 @@
 en:
   responsys_api:
+    configuration:
+      api_description_not_provided: A WSDL or endpoint+namespace is needed.
+      api_credentials_not_provided: No credentials are provided in the configuration.
     api:
       object:
         field_type:

--- a/lib/responsys/i18n/en.yml
+++ b/lib/responsys/i18n/en.yml
@@ -1,5 +1,6 @@
 en:
   responsys_api:
+    gem_is_disabled: "The query couldn't be performed because the GEM is disabled."
     configuration:
       api_description_not_provided: A WSDL or endpoint+namespace is needed.
       api_credentials_not_provided: No credentials are provided in the configuration.

--- a/lib/responsys/member.rb
+++ b/lib/responsys/member.rb
@@ -29,54 +29,70 @@ module Responsys
       data = data.merge( safe_details )
       record = RecordData.new([data])
 
-      @client.merge_list_members_riid(list, record, ListMergeRule.new(insertOnNoMatch: true, updateOnMatch: ( update_record ? 'REPLACE_ALL' : 'NO_UPDATE' )))
+      @client.run do |client|
+        client.merge_list_members_riid(list, record, ListMergeRule.new(insertOnNoMatch: true, updateOnMatch: (update_record ? 'REPLACE_ALL' : 'NO_UPDATE')))
+      end
     end
 
     def retrieve_profile_extension(profile_extension, fields)
-      return Responsys::Helper.format_response_with_message("member.riid_missing") if @user_riid.nil?
-      return Responsys::Helper.format_response_with_message("member.record_not_found") unless present_in_profile?(profile_extension)
+      @client.run do |client|
+        return Responsys::Helper.format_response_with_message("member.riid_missing") if @user_riid.nil?
+        return Responsys::Helper.format_response_with_message("member.record_not_found") unless present_in_profile?(profile_extension, true)
 
-      @client.retrieve_profile_extension_records(profile_extension, QueryColumn.new("RIID"), fields, [@user_riid])
+        client.retrieve_profile_extension_records(profile_extension, QueryColumn.new("RIID"), fields, [@user_riid])
+      end
     end
 
     def subscribe(list)
-      update(list, [{ EMAIL_ADDRESS_: @email, EMAIL_PERMISSION_STATUS_: "I" }])
+      @client.run do |client|
+        update(list, [{ EMAIL_ADDRESS_: @email, EMAIL_PERMISSION_STATUS_: "I" }])
+      end
     end
 
     def unsubscribe(list)
-      update(list, [{ EMAIL_ADDRESS_: @email, EMAIL_PERMISSION_STATUS_: "O" }])
+      @client.run do |client|
+        update(list, [{ EMAIL_ADDRESS_: @email, EMAIL_PERMISSION_STATUS_: "O" }])
+      end
     end
 
     def update(list, data)
-      return Responsys::Helper.format_response_with_message("member.record_not_found") unless present_in_list?(list)
+      @client.run(true) do |client|
+        return Responsys::Helper.format_response_with_message("member.record_not_found") unless present_in_list?(list, true)
 
-      record = RecordData.new(data)
-      @client.merge_list_members(list, record)
-    end
-
-    def present_in_profile?(list)
-      return Responsys::Helper.format_response_with_message("member.riid_missing") if @user_riid.nil?
-
-      response = lookup_profile_via_key(list, "RIID", @user_riid)
-
-      !(response[:status] == "failure" && response[:error][:code] == "RECORD_NOT_FOUND")
-    end
-
-    def present_in_list?(list)
-      if !@user_riid.nil?
-        response = lookup_list_via_key(list, "RIID", @user_riid)
-      else
-        response = lookup_list_via_key(list, "EMAIL_ADDRESS", @email)
+        record = RecordData.new(data)
+        client.merge_list_members(list, record)
       end
-
-      !(response[:status] == "failure" && response[:error][:code] == "RECORD_NOT_FOUND")
     end
 
-    def subscribed?(list)
-      return Responsys::Helper.format_response_with_message("member.record_not_found") unless present_in_list?(list)
+    def present_in_profile?(list, raising = false)
+      @client.run(raising) do |client|
+        return Responsys::Helper.format_response_with_message("member.riid_missing") if @user_riid.nil?
 
-      response = @client.retrieve_list_members(list, QueryColumn.new("EMAIL_ADDRESS"), %w(EMAIL_PERMISSION_STATUS_), [@email])
-      response[:data][0][:EMAIL_PERMISSION_STATUS_] == "I"
+        response = lookup_profile_via_key(list, "RIID", @user_riid)
+
+        !(response[:status] == "failure" && response[:error][:code] == "RECORD_NOT_FOUND")
+      end
+    end
+
+    def present_in_list?(list, raising = false)
+      @client.run(raising) do |client|
+        if !@user_riid.nil?
+          response = lookup_list_via_key(list, "RIID", @user_riid)
+        else
+          response = lookup_list_via_key(list, "EMAIL_ADDRESS", @email)
+        end
+
+        !(response[:status] == "failure" && response[:error][:code] == "RECORD_NOT_FOUND")
+      end
+    end
+
+    def subscribed?(list, raising = false)
+      @client.run(raising) do |client|
+        return Responsys::Helper.format_response_with_message("member.record_not_found") unless present_in_list?(list, true)
+
+        response = client.retrieve_list_members(list, QueryColumn.new("EMAIL_ADDRESS"), %w(EMAIL_PERMISSION_STATUS_), [@email])
+        response[:data][0][:EMAIL_PERMISSION_STATUS_] == "I"
+      end
     end
 
     private
@@ -102,11 +118,11 @@ module Responsys
     end
 
     def lookup_profile_via_key(profile_extension, key, value)
-      @client.retrieve_profile_extension_records(profile_extension, QueryColumn.new(key), %w(RIID_), [value])
+      @client.run(true) { |client| client.retrieve_profile_extension_records(profile_extension, QueryColumn.new(key), %w(RIID_), [value]) }
     end
 
     def lookup_list_via_key(list, key, value)
-      @client.retrieve_list_members(list, QueryColumn.new(key), %w(EMAIL_PERMISSION_STATUS_), [value])
+      @client.run(true) { |client| client.retrieve_list_members(list, QueryColumn.new(key), %w(EMAIL_PERMISSION_STATUS_), [value]) }
     end
   end
 end

--- a/lib/responsys/monkey_patches.rb
+++ b/lib/responsys/monkey_patches.rb
@@ -1,0 +1,17 @@
+module Responsys
+  module MonkeyPatches
+    module Object
+
+      def blank?
+        respond_to?(:empty?) ? empty? : !self
+      end unless method_defined?(:blank?)
+
+      def present?
+        !blank?
+      end unless method_defined?(:present?)
+
+    end
+  end
+end
+
+Object.send :include, Responsys::MonkeyPatches::Object

--- a/lib/responsys_api.rb
+++ b/lib/responsys_api.rb
@@ -4,6 +4,7 @@ require "savon"
 
 I18n.load_path.concat Dir.glob( File.dirname(__FILE__) + "/responsys/i18n/*.yml" )
 
+require "responsys/monkey_patches"
 require "responsys/exceptions"
 require "responsys/helper"
 require "responsys/configuration"

--- a/lib/responsys_api.rb
+++ b/lib/responsys_api.rb
@@ -4,7 +4,7 @@ require "savon"
 
 I18n.load_path.concat Dir.glob( File.dirname(__FILE__) + "/responsys/i18n/*.yml" )
 
-require "responsys/exceptions/all"
+require "responsys/exceptions"
 require "responsys/helper"
 require "responsys/configuration"
 require "responsys/api/all"

--- a/responsys-api.gemspec
+++ b/responsys-api.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "wasabi", "3.4.0"
   spec.add_dependency "i18n", ">= 0.6.9", "<= 0.7.0"
   spec.add_dependency "connection_pool", "2.1.3"
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "vcr", "~> 2.9"

--- a/spec/api/client_spec.rb
+++ b/spec/api/client_spec.rb
@@ -12,4 +12,22 @@ describe Responsys::Api::Client do
     end
   end
 
+  describe "Disabled GEM" do
+    before(:all) do
+      Responsys.configure { |config| config.settings[:enabled] = false }
+    end
+
+    after(:all) do
+      Responsys.configure { |config| config.settings[:enabled] = true }
+    end
+
+    it "should not make any call" do
+      email = DATA[:users][:user1][:EMAIL_ADDRESS]
+      list = Responsys::Api::Object::InteractObject.new(DATA[:folder],DATA[:lists][:list1][:name])
+      query_column = Responsys::Api::Object::QueryColumn.new("EMAIL_ADDRESS")
+
+      expect_any_instance_of(Responsys::Api::SessionPool).to_not receive(:with)
+      expect(subject.retrieve_list_members(list, query_column, %w(EMAIL_PERMISSION_STATUS_), [email])).to eq("disabled")
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -63,6 +63,17 @@ describe Responsys::Configuration do
     end
   end
 
+  def gem_is_disabled
+    Responsys.configure do |config|
+      config.settings = {
+        wsdl: "http://file.wsdl",
+        username: "username",
+        password: "password",
+        enabled: false
+      }
+    end
+  end
+
   describe "#configure" do
     it "should raise an exception if no api description is provided" do
       expect{ no_api_desc_configuration }.to raise_error(Responsys::Exceptions::GenericException, "A WSDL or endpoint+namespace is needed.")
@@ -128,11 +139,12 @@ describe Responsys::Configuration do
     end
   end
 
-  it "should correctly build the savon settings" do
+  it "should correctly build the savon settings with the default settings" do
     valid_configuration_with_savon_settings
 
     expect(Responsys.configuration.settings).to eq(
       {
+        enabled: true,
         wsdl: "http://file.wsdl",
         username: "username",
         password: "password",

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,150 @@
+# encoding: UTF-8
+
+require "spec_helper.rb"
+
+describe Responsys::Configuration do
+  def valid_configuration
+    Responsys.configure do |config|
+      config.settings = {
+        wsdl: "http://file.wsdl",
+        username: "username",
+        password: "password",
+        debug: false
+      }
+    end
+  end
+
+  def valid_configuration_with_endpoint
+    Responsys.configure do |config|
+      config.settings = {
+        endpoint: "http://endpoint",
+        namespace: "http://namespace",
+        username: "username",
+        password: "password",
+        debug: false,
+        sessions: {
+          size: 50
+        }
+      }
+    end
+  end
+
+  def valid_configuration_with_savon_settings
+    Responsys.configure do |config|
+      config.settings = {
+        wsdl: "http://file.wsdl",
+        username: "username",
+        password: "password",
+        debug: false,
+        savon_settings: {
+          open_timeout: 420,
+          read_timeout: 420
+        }
+      }
+    end
+  end
+
+  def no_api_desc_configuration
+    Responsys.configure do |config|
+      config.settings = {
+        username: "username",
+        password: "password",
+        debug: false
+      }
+    end
+  end
+
+  def no_api_credentials_configuration
+    Responsys.configure do |config|
+      config.settings = {
+        wsdl: "http://file.wsdl",
+        debug: false
+      }
+    end
+  end
+
+  describe "#configure" do
+    it "should raise an exception if no api description is provided" do
+      expect{ no_api_desc_configuration }.to raise_error(Responsys::Exceptions::GenericException, "A WSDL or endpoint+namespace is needed.")
+    end
+
+    it "should raise an exception if no api credentials are provided" do
+      expect{ no_api_credentials_configuration }.to raise_error(Responsys::Exceptions::GenericException, "No credentials are provided in the configuration.")
+    end    
+  end
+
+  describe "#savon_settings" do
+    it "should build the settings hash with a wsdl" do
+      valid_configuration_with_savon_settings
+
+      expect(Responsys.configuration.savon_settings).to eq(
+        {
+          wsdl: "http://file.wsdl",
+          ssl_version: :TLSv1, 
+          element_form_default: :qualified,
+          open_timeout: 420,
+          read_timeout: 420
+        }
+      )
+    end
+
+    it "should build the settings hash with an endpoint+namespace" do
+      valid_configuration_with_endpoint
+
+      expect(Responsys.configuration.savon_settings).to eq(
+        {
+          endpoint: "http://endpoint",
+          namespace: "http://namespace",
+          ssl_version: :TLSv1, 
+          element_form_default: :qualified
+        }
+      )
+    end
+  end
+
+  describe "#session_settings" do
+    it "should build the correct values" do
+      valid_configuration_with_endpoint
+
+      expect(Responsys.configuration.session_settings).to eq(
+        {
+          size: 50,
+          timeout: 30
+        }
+      )
+    end
+  end
+  
+  describe "#api_credentials" do
+    it "should be correct!" do
+      valid_configuration
+
+      expect(Responsys.configuration.api_credentials).to eq(
+        {
+          username: "username",
+          password: "password"
+        }
+      )
+    end
+  end
+
+  it "should correctly build the savon settings" do
+    valid_configuration_with_savon_settings
+
+    expect(Responsys.configuration.settings).to eq(
+      {
+        wsdl: "http://file.wsdl",
+        username: "username",
+        password: "password",
+        debug: false,
+        savon_settings: {
+          open_timeout: 420,
+          read_timeout: 420,
+          ssl_version: :TLSv1, 
+          element_form_default: :qualified
+        },
+        sessions: { size: 80, timeout: 30 }
+      }
+    )
+  end
+end

--- a/spec/fixtures/vcr_cassettes/member/has_subscribed.yml
+++ b/spec/fixtures/vcr_cassettes/member/has_subscribed.yml
@@ -1,0 +1,1037 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ws5.responsys.net/webservices/wsdl/ResponsysWS_Level1.wsdl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: "<?xml version='1.0' encoding='UTF-8'?>\n<definitions targetNamespace=\"urn:ws.rsys.com\"
+        \n             xmlns=\"http://schemas.xmlsoap.org/wsdl/\" \n             xmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"
+        \n             xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"\n             xmlns:tns=\"urn:ws.rsys.com\"\n
+        \            xmlns:fns=\"urn:fault.ws.rsys.com\">\n    <documentation>This
+        WSDL contains the APIs needed for customers to integrate their applications
+        with Responsys Interact.</documentation>\n    <types>\n        <xsd:schema>\n
+        \           <xsd:import namespace=\"urn:ws.rsys.com\" schemaLocation=\"../services/ResponsysWSService/_resources_/xsd/ResponsysWSTypes_Schema.xsd\"/>\n
+        \       </xsd:schema>\n        \n        <xsd:schema>\n            <xsd:import
+        namespace=\"urn:fault.ws.rsys.com\" schemaLocation=\"../services/ResponsysWSService/_resources_/xsd/ResponsysWSFaults_Schema.xsd\"/>\n
+        \       </xsd:schema>\n    </types>\n    \n    <!-- Header Message -->\n    <message
+        name=\"Header\">\n        <part element=\"tns:SessionHeader\" name=\"SessionHeader\"/>\n
+        \   </message>\n    \n    <message name=\"AuthHeader\">\n        <part element=\"tns:AuthSessionHeader\"
+        name=\"AuthSessionHeader\"/>\n    </message>\n    <!-- Header Message -->\n
+        \   \n    <!-- Fault Messages -->\n    <message name=\"ApiFault\">\n        <part
+        name=\"fault\" type=\"fns:ApiFault\"/>\n    </message>\n\n  <message name=\"DuplicateApiRequestFault\">\n
+        \   <part name=\"fault\" element=\"fns:DuplicateApiRequestFault\"/>\n  </message>\n\n
+        \   <message name=\"AccountFault\">\n        <part name=\"fault\" element=\"fns:AccountFault\"/>\n
+        \   </message>\n    \n    <message name=\"FolderFault\">\n        <part name=\"fault\"
+        element=\"fns:FolderFault\"/>\n    </message>\n    \n    <message name=\"TriggeredMessageFault\">\n
+        \       <part name=\"fault\" element=\"fns:TriggeredMessageFault\"/>\n    </message>\n
+        \   \n    <message name=\"CustomEventFault\">\n        <part name=\"fault\"
+        element=\"fns:CustomEventFault\"/>\n    </message>\n    \n    <message name=\"CampaignFault\">\n
+        \       <part name=\"fault\" element=\"fns:CampaignFault\"/>\n    </message>\n
+        \   \n    <message name=\"ListFault\">\n        <part name=\"fault\" element=\"fns:ListFault\"/>\n
+        \   </message>\n    \n    <message name=\"TableFault\">\n        <part name=\"fault\"
+        element=\"fns:TableFault\"/>\n    </message>\n    \n    <message name=\"DocumentFault\">\n
+        \       <part name=\"fault\" element=\"fns:DocumentFault\"/>\n    </message>\n
+        \   \n    <message name=\"ConnectFault\">\n        <part name=\"fault\" element=\"fns:ConnectFault\"/>\n
+        \   </message>\n    \n    <message name=\"ListExtensionFault\">\n        <part
+        name=\"fault\" element=\"fns:ListExtensionFault\"/>\n    </message>\n    \n
+        \   <message name=\"UnexpectedErrorFault\">\n        <part name=\"fault\"
+        element=\"fns:UnexpectedErrorFault\"/>\n    </message>\n    \n    <message
+        name=\"UnrecoverableErrorFault\">\n        <part name=\"fault\" element=\"fns:UnrecoverableErrorFault\"/>\n
+        \   </message>\n    <!-- Fault Messages -->\n    \n    <message name=\"loginRequest\">\n
+        \       <part element=\"tns:login\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"loginResponse\">\n        <part element=\"tns:loginResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"authenticateServerRequest\">\n
+        \       <part element=\"tns:authenticateServer\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"authenticateServerResponse\">\n        <part element=\"tns:authenticateServerResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"loginWithCertificateRequest\">\n
+        \       <part element=\"tns:loginWithCertificate\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"loginWithCertificateResponse\">\n
+        \       <part element=\"tns:loginWithCertificateResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"logoutRequest\">\n        <part
+        element=\"tns:logout\" name=\"parameters\"/>\n    </message>\n    \n    <message
+        name=\"logoutResponse\">\n        <part element=\"tns:logoutResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"createFolderRequest\">\n        <part
+        element=\"tns:createFolder\" name=\"parameters\"/>\n    </message>\n    \n
+        \   <message name=\"createFolderResponse\">\n        <part element=\"tns:createFolderResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"deleteFolderRequest\">\n
+        \       <part element=\"tns:deleteFolder\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"deleteFolderResponse\">\n        <part element=\"tns:deleteFolderResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"listFoldersRequest\">\n
+        \       <part element=\"tns:listFolders\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"listFoldersResponse\">\n        <part element=\"tns:listFoldersResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"triggerCampaignMessageRequest\">\n
+        \       <part element=\"tns:triggerCampaignMessage\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"triggerCampaignMessageResponse\">\n
+        \       <part element=\"tns:triggerCampaignMessageResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"HaMergeTriggerEmailRequest\">\n
+        \       <part element=\"tns:HaMergeTriggerEmail\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"HaMergeTriggerEmailResponse\">\n
+        \       <part element=\"tns:HaMergeTriggerEmailResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n     <message name=\"mergeTriggerEmailRequest\">\n        <part
+        element=\"tns:mergeTriggerEmail\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"mergeTriggerEmailResponse\">\n        <part element=\"tns:mergeTriggerEmailResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"mergeTriggerSMSRequest\">\n
+        \       <part element=\"tns:mergeTriggerSMS\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"mergeTriggerSMSResponse\">\n        <part element=\"tns:mergeTriggerSMSResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"triggerCustomEventRequest\">\n
+        \       <part element=\"tns:triggerCustomEvent\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"triggerCustomEventResponse\">\n        <part element=\"tns:triggerCustomEventResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"launchCampaignRequest\">\n
+        \       <part element=\"tns:launchCampaign\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"launchCampaignResponse\">\n        <part element=\"tns:launchCampaignResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"scheduleCampaignLaunchRequest\">\n
+        \       <part element=\"tns:scheduleCampaignLaunch\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"scheduleCampaignLaunchResponse\">\n
+        \       <part element=\"tns:scheduleCampaignLaunchResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"getLaunchStatusRequest\">\n        <part
+        element=\"tns:getLaunchStatus\" name=\"parameters\"/>\n    </message>\n    \n
+        \   <message name=\"getLaunchStatusResponse\">\n        <part element=\"tns:getLaunchStatusResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"mergeListMembersRequest\">\n
+        \       <part element=\"tns:mergeListMembers\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"mergeListMembersResponse\">\n        <part element=\"tns:mergeListMembersResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"retrieveListMembersRequest\">\n
+        \       <part element=\"tns:retrieveListMembers\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"retrieveListMembersResponse\">\n
+        \       <part element=\"tns:retrieveListMembersResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"deleteListMembersRequest\">\n        <part
+        element=\"tns:deleteListMembers\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"deleteListMembersResponse\">\n        <part element=\"tns:deleteListMembersResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"deleteProfileExtensionMembersRequest\">\n
+        \       <part element=\"tns:deleteProfileExtensionMembers\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"deleteProfileExtensionMembersResponse\">\n
+        \       <part element=\"tns:deleteProfileExtensionMembersResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"createTableRequest\">\n        <part
+        element=\"tns:createTable\" name=\"parameters\"/>\n    </message>\n    \n
+        \   <message name=\"createTableResponse\">\n        <part element=\"tns:createTableResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"deleteTableRequest\">\n
+        \       <part element=\"tns:deleteTable\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"deleteTableResponse\">\n        <part element=\"tns:deleteTableResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"mergeTableRecordsRequest\">\n
+        \       <part element=\"tns:mergeTableRecords\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"mergeTableRecordsResponse\">\n        <part element=\"tns:mergeTableRecordsResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"retrieveTableRecordsRequest\">\n
+        \       <part element=\"tns:retrieveTableRecords\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"retrieveTableRecordsResponse\">\n
+        \       <part element=\"tns:retrieveTableRecordsResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"deleteTableRecordsRequest\">\n        <part
+        element=\"tns:deleteTableRecords\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"deleteTableRecordsResponse\">\n        <part element=\"tns:deleteTableRecordsResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"truncateTableRequest\">\n
+        \       <part element=\"tns:truncateTable\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"truncateTableResponse\">\n        <part element=\"tns:truncateTableResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"createDocumentRequest\">\n
+        \       <part element=\"tns:createDocument\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"createDocumentResponse\">\n        <part element=\"tns:createDocumentResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"deleteDocumentRequest\">\n
+        \       <part element=\"tns:deleteDocument\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"deleteDocumentResponse\">\n        <part element=\"tns:deleteDocumentResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"setDocumentImagesRequest\">\n
+        \       <part element=\"tns:setDocumentImages\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"setDocumentImagesResponse\">\n        <part element=\"tns:setDocumentImagesResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"getDocumentImagesRequest\">\n
+        \       <part element=\"tns:getDocumentImages\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"getDocumentImagesResponse\">\n        <part element=\"tns:getDocumentImagesResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"setDocumentContentRequest\">\n
+        \       <part element=\"tns:setDocumentContent\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"setDocumentContentResponse\">\n        <part element=\"tns:setDocumentContentResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"getDocumentContentRequest\">\n
+        \       <part element=\"tns:getDocumentContent\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"getDocumentContentResponse\">\n        <part element=\"tns:getDocumentContentResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"mergeListMembersRIIDRequest\">\n
+        \       <part element=\"tns:mergeListMembersRIID\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"mergeListMembersRIIDResponse\">\n
+        \       <part element=\"tns:mergeListMembersRIIDResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"mergeIntoProfileExtensionRequest\">\n
+        \       <part element=\"tns:mergeIntoProfileExtension\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"mergeIntoProfileExtensionResponse\">\n
+        \       <part element=\"tns:mergeIntoProfileExtensionResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"createTableWithPKRequest\">\n        <part
+        element=\"tns:createTableWithPK\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"createTableWithPKResponse\">\n        <part element=\"tns:createTableWithPKResponse\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"mergeTableRecordsWithPKRequest\">\n
+        \       <part element=\"tns:mergeTableRecordsWithPK\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"mergeTableRecordsWithPKResponse\">\n
+        \       <part element=\"tns:mergeTableRecordsWithPKResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"retrieveProfileExtensionRecordsRequest\">\n
+        \       <part element=\"tns:retrieveProfileExtensionRecords\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"retrieveProfileExtensionRecordsResponse\">\n
+        \       <part element=\"tns:retrieveProfileExtensionRecordsResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <!-- Content library related message -->\n    <message
+        name=\"listContentLibraryFoldersRequest\">\n        <part element=\"tns:listContentLibraryFolders\"
+        name=\"parameters\"/>\n    </message>\n    \n    <message name=\"listContentLibraryFoldersResponse\">\n
+        \       <part element=\"tns:listContentLibraryFoldersResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"doesContentLibraryFolderExistRequest\">\n
+        \       <part element=\"tns:doesContentLibraryFolderExist\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"doesContentLibraryFolderExistResponse\">\n
+        \       <part element=\"tns:doesContentLibraryFolderExistResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"deleteContentLibraryFolderRequest\">\n
+        \       <part element=\"tns:deleteContentLibraryFolder\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"deleteContentLibraryFolderResponse\">\n
+        \       <part element=\"tns:deleteContentLibraryFolderResponse\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"createContentLibraryFolderRequest\">\n
+        \       <part element=\"tns:createContentLibraryFolder\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"createContentLibraryFolderResponse\">\n
+        \       <part element=\"tns:createContentLibraryFolderResponse\" name=\"parameters\"/>\n
+        \   </message> \n    \n    <message name=\"createContentLibraryItemRequest\">\n
+        \       <part element=\"tns:createContentLibraryItem\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"createContentLibraryItemResponse\">\n
+        \       <part element=\"tns:createContentLibraryItemResponse\" name=\"parameters\"/>\n
+        \   </message>     \n\n\t<message name=\"setContentLibraryItemRequest\">\n
+        \       <part element=\"tns:setContentLibraryItem\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"setContentLibraryItemResponse\">\n
+        \       <part element=\"tns:setContentLibraryItemResponse\" name=\"parameters\"/>\n
+        \   </message>   \n    \n\t<message name=\"deleteContentLibraryItemRequest\">\n
+        \       <part element=\"tns:deleteContentLibraryItem\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"deleteContentLibraryItemResponse\">\n
+        \       <part element=\"tns:deleteContentLibraryItemResponse\" name=\"parameters\"/>\n
+        \   </message>   \n    \n\t<message name=\"getContentLibraryItemRequest\">\n
+        \       <part element=\"tns:getContentLibraryItem\" name=\"parameters\"/>\n
+        \   </message>\n    \n    <message name=\"getContentLibraryItemResponse\">\n
+        \       <part element=\"tns:getContentLibraryItemResponse\" name=\"parameters\"/>\n
+        \   </message>     \n    \n    <message name=\"HaMergeTriggerSmsRequest\">\n
+        \       <part element=\"tns:HaMergeTriggerSms\" name=\"parameters\"/>\n    </message>\n
+        \   \n    <message name=\"HaMergeTriggerSmsResponse\">\n        <part element=\"tns:HaMergeTriggerSmsResponse\"
+        name=\"parameters\"/>\n    </message>\n     <message name=\"createProfileExtensionTableRequest\">\n
+        \       <part name=\"parameters\" element=\"tns:createProfileExtensionTable\"/>\n
+        \   </message>\n    <message name=\"createProfileExtensionTableResponse\">\n
+        \       <part name=\"parameters\" element=\"tns:createProfileExtensionTableResponse\"/>\n
+        \   </message>\n    <portType name=\"ResponsysWS\">\n        <operation name=\"login\">\n
+        \           <documentation>Login to the Responsys Web Services API.</documentation>\n
+        \           <input  message=\"tns:loginRequest\" name=\"loginRequest\"/>\n
+        \           <output message=\"tns:loginResponse\" name=\"loginResponse\"/>\n
+        \           <fault  message=\"tns:AccountFault\" name=\"AccountFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"authenticateServer\">\n
+        \           <documentation>Auhenticate the server.</documentation>\n            <input
+        \ message=\"tns:authenticateServerRequest\" name=\"authenticateServerRequest\"/>\n
+        \           <output message=\"tns:authenticateServerResponse\" name=\"authenticateServerResponse\"/>\n
+        \           <fault  message=\"tns:AccountFault\" name=\"AccountFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"loginWithCertificate\">\n
+        \           <documentation>Login to the Responsys Web Services API using Certificate.</documentation>\n
+        \           <input  message=\"tns:loginWithCertificateRequest\" name=\"loginWithCertificateRequest\"/>\n
+        \           <output message=\"tns:loginWithCertificateResponse\" name=\"loginWithCertificateResponse\"/>\n
+        \           <fault  message=\"tns:AccountFault\" name=\"AccountFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"logout\">\n            <documentation>Logout
+        of the Responsys Web Services API.</documentation>\n            <input  message=\"tns:logoutRequest\"
+        name=\"logoutRequest\"/>\n            <output message=\"tns:logoutResponse\"
+        name=\"logoutResponse\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"createFolder\">\n            <documentation>Creates a new folder.</documentation>\n
+        \           <input  message=\"tns:createFolderRequest\" name=\"createFolderRequest\"/>\n
+        \           <output message=\"tns:createFolderResponse\" name=\"createFolderResponse\"/>\n
+        \           <fault  message=\"tns:FolderFault\" name=\"FolderFault\"/>\n            <fault
+        \ message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n        </operation>\n
+        \       \n        <operation name=\"deleteFolder\">\n            <documentation>Deletes
+        an existing folder.</documentation>\n            <input  message=\"tns:deleteFolderRequest\"
+        name=\"deleteFolderRequest\"/>\n            <output message=\"tns:deleteFolderResponse\"
+        name=\"deleteFolderResponse\"/>\n            <fault  message=\"tns:FolderFault\"
+        name=\"FolderFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"listFolders\">\n            <documentation>List folders in the Responsys
+        account.</documentation>\n            <input  message=\"tns:listFoldersRequest\"
+        name=\"listFoldersRequest\"/>\n            <output message=\"tns:listFoldersResponse\"
+        name=\"listFoldersResponse\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"triggerCampaignMessage\">\n            <documentation>Send Triggered
+        Message to 1 or more recipients.</documentation>\n            <input  message=\"tns:triggerCampaignMessageRequest\"
+        name=\"triggerCampaignMessageRequest\"/>\n            <output message=\"tns:triggerCampaignMessageResponse\"
+        name=\"triggerCampaignMessageResponse\"/>\n            <fault  message=\"tns:TriggeredMessageFault\"
+        name=\"TriggeredMessageFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n            <fault message=\"tns:DuplicateApiRequestFault\"
+        name=\"DuplicateApiRequestFault\" />\n        </operation>\n        \n        <operation
+        name=\"HaMergeTriggerEmail\">\n            <documentation>Merge And Send Triggered
+        Message for 1 or more recipients.</documentation>\n            <input  message=\"tns:HaMergeTriggerEmailRequest\"
+        name=\"HaMergeTriggerEmailRequest\"/>\n            <output message=\"tns:HaMergeTriggerEmailResponse\"
+        name=\"HaMergeTriggerEmailResponse\"/>\n            <fault  message=\"tns:TriggeredMessageFault\"
+        name=\"TriggeredMessageFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n            <fault  message=\"tns:UnrecoverableErrorFault\"
+        name=\"UnrecoverableErrorFault\"/>\n            <fault message=\"tns:DuplicateApiRequestFault\"
+        name=\"DuplicateApiRequestFault\"/>\n        </operation>\n        \n        <operation
+        name=\"mergeTriggerEmail\">\n            <documentation>Merge And Send Triggered
+        Message for 1 or more recipients.</documentation>\n            <input  message=\"tns:mergeTriggerEmailRequest\"
+        name=\"mergeTriggerEmailRequest\"/>\n            <output message=\"tns:mergeTriggerEmailResponse\"
+        name=\"mergeTriggerEmailResponse\"/>\n            <fault  message=\"tns:TriggeredMessageFault\"
+        name=\"TriggeredMessageFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n            <fault message=\"tns:DuplicateApiRequestFault\"
+        name=\"DuplicateApiRequestFault\"/>\n        </operation>\n        \n        <operation
+        name=\"mergeTriggerSMS\">\n            <documentation>Merge And Send Triggered
+        Message for 1 or more recipients.</documentation>\n            <input  message=\"tns:mergeTriggerSMSRequest\"
+        name=\"mergeTriggerSMSRequest\"/>\n            <output message=\"tns:mergeTriggerSMSResponse\"
+        name=\"mergeTriggerSMSResponse\"/>\n            <fault  message=\"tns:TriggeredMessageFault\"
+        name=\"TriggeredMessageFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n            <fault message=\"tns:DuplicateApiRequestFault\"
+        name=\"DuplicateApiRequestFault\"/>\n        </operation>\n        \n        <operation
+        name=\"triggerCustomEvent\">\n            <documentation>Trigger Custom Event
+        to 1 or more recipients.</documentation>\n            <input  message=\"tns:triggerCustomEventRequest\"
+        name=\"triggerCustomEventRequest\"/>\n            <output message=\"tns:triggerCustomEventResponse\"
+        name=\"triggerCustomEventResponse\"/>\n            <fault  message=\"tns:CustomEventFault\"
+        name=\"CustomEventFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n            <fault message=\"tns:DuplicateApiRequestFault\"
+        name=\"DuplicateApiRequestFault\" />\n        </operation>\n        \n        <operation
+        name=\"launchCampaign\">\n            <documentation>Launch a Campaign Immediately.</documentation>\n
+        \           <input  message=\"tns:launchCampaignRequest\" name=\"launchCampaignRequest\"/>\n
+        \           <output message=\"tns:launchCampaignResponse\" name=\"launchCampaignResponse\"/>\n
+        \           <fault  message=\"tns:CampaignFault\" name=\"CampaignFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"scheduleCampaignLaunch\">\n
+        \           <documentation>Schedule a Campaign Launch.</documentation>\n            <input
+        \ message=\"tns:scheduleCampaignLaunchRequest\" name=\"scheduleCampaignLaunchRequest\"/>\n
+        \           <output message=\"tns:scheduleCampaignLaunchResponse\" name=\"scheduleCampaignLaunchResponse\"/>\n
+        \           <fault  message=\"tns:CampaignFault\" name=\"CampaignFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"getLaunchStatus\">\n
+        \           <documentation>Gets the launch info given a launch Id.</documentation>\n
+        \           <input  message=\"tns:getLaunchStatusRequest\" name=\"getLaunchStatusRequest\"/>\n
+        \           <output message=\"tns:getLaunchStatusResponse\" name=\"getLaunchStatusResponse\"/>\n
+        \           <fault  message=\"tns:CampaignFault\" name=\"CampaignFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"mergeListMembers\">\n
+        \           <documentation>Merge data into a list.</documentation>\n            <input
+        \ message=\"tns:mergeListMembersRequest\" name=\"mergeListMembersRequest\"/>\n
+        \           <output message=\"tns:mergeListMembersResponse\" name=\"mergeListMembersResponse\"/>\n
+        \           <fault  message=\"tns:ListFault\" name=\"ListFault\"/>\n            <fault
+        \ message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n        </operation>\n
+        \       \n        <operation name=\"retrieveListMembers\">\n            <documentation>Retrieves
+        recipients from a list.</documentation>\n            <input  message=\"tns:retrieveListMembersRequest\"
+        name=\"retrieveListMembersRequest\"/>\n            <output message=\"tns:retrieveListMembersResponse\"
+        name=\"retrieveListMembersResponse\"/>\n            <fault  message=\"tns:ListFault\"
+        name=\"ListFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"deleteListMembers\">\n            <documentation>Deletes recipients
+        from a list.</documentation>\n            <input  message=\"tns:deleteListMembersRequest\"
+        name=\"deleteListMembersRequest\"/>\n            <output message=\"tns:deleteListMembersResponse\"
+        name=\"deleteListMembersResponse\"/>\n            <fault  message=\"tns:ListFault\"
+        name=\"ListFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"deleteProfileExtensionMembers\">\n            <documentation>Deletes
+        recipients from a profile extension.</documentation>\n            <input  message=\"tns:deleteProfileExtensionMembersRequest\"
+        name=\"deleteProfileExtensionMembersRequest\"/>\n            <output message=\"tns:deleteProfileExtensionMembersResponse\"
+        name=\"deleteProfileExtensionMembersResponse\"/>\n            <fault  message=\"tns:ListExtensionFault\"
+        name=\"ListExtensionFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"createTable\">\n            <documentation>Creates an empty table.</documentation>\n
+        \           <input  message=\"tns:createTableRequest\" name=\"createTableRequest\"/>\n
+        \           <output message=\"tns:createTableResponse\" name=\"createTableResponse\"/>\n
+        \           <fault  message=\"tns:TableFault\" name=\"TableFault\"/>\n            <fault
+        \ message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n        </operation>\n
+        \       \n        <operation name=\"deleteTable\">\n            <documentation>Deletes
+        an existing table.</documentation>\n            <input  message=\"tns:deleteTableRequest\"
+        name=\"deleteTableRequest\"/>\n            <output message=\"tns:deleteTableResponse\"
+        name=\"deleteTableResponse\"/>\n            <fault  message=\"tns:TableFault\"
+        name=\"TableFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"mergeTableRecords\">\n            <documentation>Merge data into a
+        table.</documentation>\n            <input  message=\"tns:mergeTableRecordsRequest\"
+        name=\"mergeTableRecordsRequest\"/>\n            <output message=\"tns:mergeTableRecordsResponse\"
+        name=\"mergeTableRecordsResponse\"/>\n            <fault  message=\"tns:TableFault\"
+        name=\"TableFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"retrieveTableRecords\">\n            <documentation>Retrieves records
+        from table.</documentation>\n            <input  message=\"tns:retrieveTableRecordsRequest\"
+        name=\"retrieveTableRecordsRequest\"/>\n            <output message=\"tns:retrieveTableRecordsResponse\"
+        name=\"retrieveTableRecordsResponse\"/>\n            <fault  message=\"tns:TableFault\"
+        name=\"TableFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"deleteTableRecords\">\n            <documentation>Deletes records from
+        a table.</documentation>\n            <input  message=\"tns:deleteTableRecordsRequest\"
+        name=\"deleteTableRecordsRequest\"/>\n            <output message=\"tns:deleteTableRecordsResponse\"
+        name=\"deleteTableRecordsResponse\"/>\n            <fault  message=\"tns:TableFault\"
+        name=\"TableFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"truncateTable\">\n            <documentation>Truncate data in existing
+        table.</documentation>\n            <input  message=\"tns:truncateTableRequest\"
+        name=\"truncateTableRequest\"/>\n            <output message=\"tns:truncateTableResponse\"
+        name=\"truncateTableResponse\"/>\n            <fault  message=\"tns:TableFault\"
+        name=\"TableFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"createDocument\">\n            <documentation>Creates a document.</documentation>\n
+        \           <input  message=\"tns:createDocumentRequest\" name=\"createDocumentRequest\"/>\n
+        \           <output message=\"tns:createDocumentResponse\" name=\"createDocumentResponse\"/>\n
+        \           <fault  message=\"tns:DocumentFault\" name=\"DocumentFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"deleteDocument\">\n
+        \           <documentation>Deletes a document.</documentation>\n            <input
+        \ message=\"tns:deleteDocumentRequest\" name=\"deleteDocumentRequest\"/>\n
+        \           <output message=\"tns:deleteDocumentResponse\" name=\"deleteDocumentResponse\"/>\n
+        \           <fault  message=\"tns:DocumentFault\" name=\"DocumentFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"setDocumentImages\">\n
+        \           <documentation>Set images to a document.</documentation>\n            <input
+        \ message=\"tns:setDocumentImagesRequest\" name=\"setDocumentImagesRequest\"/>\n
+        \           <output message=\"tns:setDocumentImagesResponse\" name=\"setDocumentImagesResponse\"/>\n
+        \           <fault  message=\"tns:DocumentFault\" name=\"DocumentFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"getDocumentImages\">\n
+        \           <documentation>Get images from a document.</documentation>\n            <input
+        \ message=\"tns:getDocumentImagesRequest\" name=\"getDocumentImagesRequest\"/>\n
+        \           <output message=\"tns:getDocumentImagesResponse\" name=\"getDocumentImagesResponse\"/>\n
+        \           <fault  message=\"tns:DocumentFault\" name=\"DocumentFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"setDocumentContent\">\n
+        \           <documentation>Set content to a document.</documentation>\n            <input
+        \ message=\"tns:setDocumentContentRequest\" name=\"setDocumentContentRequest\"/>\n
+        \           <output message=\"tns:setDocumentContentResponse\" name=\"setDocumentContentResponse\"/>\n
+        \           <fault  message=\"tns:DocumentFault\" name=\"DocumentFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"getDocumentContent\">\n
+        \           <documentation>Get content of a document.</documentation>\n            <input
+        \ message=\"tns:getDocumentContentRequest\" name=\"getDocumentContentRequest\"/>\n
+        \           <output message=\"tns:getDocumentContentResponse\" name=\"getDocumentContentResponse\"/>\n
+        \           <fault  message=\"tns:DocumentFault\" name=\"DocumentFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"mergeListMembersRIID\">\n
+        \           <documentation>Merge data into a list returning the recipient
+        ids.</documentation>\n            <input  message=\"tns:mergeListMembersRIIDRequest\"
+        name=\"mergeListMembersRIIDRequest\"/>\n            <output message=\"tns:mergeListMembersRIIDResponse\"
+        name=\"mergeListMembersRIIDResponse\"/>\n            <fault  message=\"tns:ListFault\"
+        name=\"ListFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"mergeIntoProfileExtension\">\n            <documentation>Merge data
+        into a list extension returning the recipient ids.</documentation>\n            <input
+        \ message=\"tns:mergeIntoProfileExtensionRequest\" name=\"mergeIntoProfileExtensionRequest\"/>\n
+        \           <output message=\"tns:mergeIntoProfileExtensionResponse\" name=\"mergeIntoProfileExtensionResponse\"/>\n
+        \           <fault  message=\"tns:ListExtensionFault\" name=\"ListExtensionFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \       </operation>\n        \n        <operation name=\"createTableWithPK\">\n
+        \           <documentation>Creates an empty table with primary keys.</documentation>\n
+        \           <input  message=\"tns:createTableWithPKRequest\" name=\"createTableWithPKRequest\"/>\n
+        \           <output message=\"tns:createTableWithPKResponse\" name=\"createTableWithPKResponse\"/>\n
+        \           <fault  message=\"tns:TableFault\" name=\"TableFault\"/>\n            <fault
+        \ message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n        </operation>\n
+        \       \n        <operation name=\"mergeTableRecordsWithPK\">\n            <documentation>Merge
+        data into a table using primary keys.</documentation>\n            <input
+        \ message=\"tns:mergeTableRecordsWithPKRequest\" name=\"mergeTableRecordsWithPKRequest\"/>\n
+        \           <output message=\"tns:mergeTableRecordsWithPKResponse\" name=\"mergeTableRecordsWithPKResponse\"/>\n
+        \           <fault  message=\"tns:TableFault\" name=\"TableFault\"/>\n            <fault
+        \ message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n        </operation>\n
+        \       \n        <operation name=\"retrieveProfileExtensionRecords\">\n            <documentation>Retrieves
+        records from a list extension.</documentation>\n            <input  message=\"tns:retrieveProfileExtensionRecordsRequest\"
+        name=\"retrieveProfileExtensionRecordsRequest\"/>\n            <output message=\"tns:retrieveProfileExtensionRecordsResponse\"
+        name=\"retrieveProfileExtensionRecordsResponse\"/>\n            <fault  message=\"tns:ListExtensionFault\"
+        name=\"ListExtensionFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <!--
+        Content library related operations -->\n        <operation name=\"listContentLibraryFolders\">\n
+        \           <documentation>List folders in the Content Library.</documentation>\n
+        \           <input  message=\"tns:listContentLibraryFoldersRequest\" name=\"listContentLibraryFoldersRequest\"/>\n
+        \           <output message=\"tns:listContentLibraryFoldersResponse\" name=\"listContentLibraryFoldersResponse\"/>\n
+        \           <fault  message=\"tns:FolderFault\" name=\"FolderFault\"/>\n            <fault
+        \ message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n        </operation>\n
+        \       \n        <operation name=\"doesContentLibraryFolderExist\">\n\t\t\t<documentation>Check
+        if folder exists in the Content Library.</documentation>\n\t\t\t<input  message=\"tns:doesContentLibraryFolderExistRequest\"
+        name=\"doesContentLibraryFolderExistRequest\"/>\n\t\t\t<output message=\"tns:doesContentLibraryFolderExistResponse\"
+        name=\"doesContentLibraryFolderExistResponse\"/>\n\t\t\t<fault  message=\"tns:FolderFault\"
+        name=\"FolderFault\"/>\n\t\t\t<fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n\t\t</operation>\n        \n        <operation
+        name=\"deleteContentLibraryFolder\">\n            <documentation>Delete folder
+        in the Content Library.</documentation>\n            <input  message=\"tns:deleteContentLibraryFolderRequest\"
+        name=\"deleteContentLibraryFolderRequest\"/>\n            <output message=\"tns:deleteContentLibraryFolderResponse\"
+        name=\"deleteContentLibraryFolderResponse\"/>\n            <fault  message=\"tns:FolderFault\"
+        name=\"FolderFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"createContentLibraryFolder\">\n            <documentation>Create folder
+        in the Content Library.</documentation>\n            <input  message=\"tns:createContentLibraryFolderRequest\"
+        name=\"createContentLibraryFolderRequest\"/>\n            <output message=\"tns:createContentLibraryFolderResponse\"
+        name=\"createContentLibraryFolderResponse\"/>\n            <fault  message=\"tns:FolderFault\"
+        name=\"FolderFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"createContentLibraryItem\">\n            <documentation>Create asset
+        in the Content Library.</documentation>\n            <input  message=\"tns:createContentLibraryItemRequest\"
+        name=\"createContentLibraryItemRequest\"/>\n            <output message=\"tns:createContentLibraryItemResponse\"
+        name=\"createContentLibraryItemResponse\"/>\n            <fault  message=\"tns:DocumentFault\"
+        name=\"DocumentFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>   \n\n        <operation
+        name=\"setContentLibraryItem\">\n            <documentation>Update asset in
+        the Content Library.</documentation>\n            <input  message=\"tns:setContentLibraryItemRequest\"
+        name=\"setContentLibraryItemRequest\"/>\n            <output message=\"tns:setContentLibraryItemResponse\"
+        name=\"setContentLibraryItemResponse\"/>\n            <fault  message=\"tns:DocumentFault\"
+        name=\"DocumentFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>\n        \n        <operation
+        name=\"deleteContentLibraryItem\">\n            <documentation>Delete asset
+        in the Content Library.</documentation>\n            <input  message=\"tns:deleteContentLibraryItemRequest\"
+        name=\"deleteContentLibraryItemRequest\"/>\n            <output message=\"tns:deleteContentLibraryItemResponse\"
+        name=\"deleteContentLibraryItemResponse\"/>\n            <fault  message=\"tns:DocumentFault\"
+        name=\"DocumentFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>    \n        \n        <operation
+        name=\"getContentLibraryItem\">\n            <documentation>Get asset in the
+        Content Library.</documentation>\n            <input  message=\"tns:getContentLibraryItemRequest\"
+        name=\"getContentLibraryItemRequest\"/>\n            <output message=\"tns:getContentLibraryItemResponse\"
+        name=\"getContentLibraryItemResponse\"/>\n            <fault  message=\"tns:DocumentFault\"
+        name=\"DocumentFault\"/>\n            <fault  message=\"tns:UnexpectedErrorFault\"
+        name=\"UnexpectedErrorFault\"/>\n        </operation>        \n        \n
+        \       <operation name=\"HaMergeTriggerSms\">\n            <documentation>Merge
+        And Send Triggered Message for 1 or more recipients.</documentation>\n            <input
+        \ message=\"tns:HaMergeTriggerSmsRequest\" name=\"HaMergeTriggerSmsRequest\"/>\n
+        \           <output message=\"tns:HaMergeTriggerSmsResponse\" name=\"HaMergeTriggerSmsResponse\"/>\n
+        \           <fault  message=\"tns:TriggeredMessageFault\" name=\"TriggeredMessageFault\"/>\n
+        \           <fault  message=\"tns:UnexpectedErrorFault\" name=\"UnexpectedErrorFault\"/>\n
+        \           <fault  message=\"tns:UnrecoverableErrorFault\" name=\"UnrecoverableErrorFault\"/>\n
+        \           <fault message=\"tns:DuplicateApiRequestFault\" name=\"DuplicateApiRequestFault\"
+        />\n        </operation>\n        <operation name=\"createProfileExtensionTable\">\n
+        \           <input name=\"createProfileExtensionTableRequest\"\n                message=\"tns:createProfileExtensionTableRequest\"/>\n
+        \           <output name=\"createProfileExtensionTableResponse\"\n                message=\"tns:createProfileExtensionTableResponse\"/>\n
+        \           <fault name=\"ListFault\" message=\"tns:ListFault\"/>\n        </operation>\n
+        \   </portType>\n    \n    <binding name=\"ResponsysWSSoapBinding\" type=\"tns:ResponsysWS\">\n
+        \       <soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"/>\n
+        \       \n        <operation name=\"login\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input name=\"loginRequest\">\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"loginResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"AccountFault\">\n               <soap:fault name=\"AccountFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"authenticateServer\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"authenticateServerRequest\">\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"authenticateServerResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"AccountFault\">\n               <soap:fault name=\"AccountFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"loginWithCertificate\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"loginWithCertificateRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:AuthHeader\" part=\"AuthSessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"loginWithCertificateResponse\">\n                <soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"AccountFault\">\n               <soap:fault
+        name=\"AccountFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n               <soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>\n        </operation>\n        \n
+        \       <operation name=\"logout\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"logoutRequest\">\n                <soap:header use=\"literal\"
+        message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"logoutResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"UnexpectedErrorFault\">\n               <soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>\n        </operation>\n        \n
+        \       <operation name=\"createFolder\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"createFolderRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"createFolderResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"FolderFault\">\n               <soap:fault name=\"FolderFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"deleteFolder\">\n            <soap:operation soapAction=\"\"/>\n            <input
+        name=\"deleteFolderRequest\">\n                <soap:header use=\"literal\"
+        message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"deleteFolderResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"FolderFault\">\n               <soap:fault name=\"FolderFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"listFolders\">\n            <soap:operation soapAction=\"\"/>\n            <input
+        name=\"listFoldersRequest\">\n                <soap:header use=\"literal\"
+        message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"listFoldersResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"UnexpectedErrorFault\">\n               <soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>\n        </operation>\n        \n
+        \       <operation name=\"triggerCampaignMessage\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input name=\"triggerCampaignMessageRequest\">\n
+        \               <soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"triggerCampaignMessageResponse\">\n                <soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"TriggeredMessageFault\">\n
+        \               <soap:fault name=\"TriggeredMessageFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"DuplicateApiRequestFault\">\n
+        \             <soap:fault name=\"DuplicateApiRequestFault\" use=\"literal\"
+        />\n            </fault>\n        </operation>\n        \n        <operation
+        name=\"HaMergeTriggerEmail\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"HaMergeTriggerEmailRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"HaMergeTriggerEmailResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TriggeredMessageFault\">\n                <soap:fault name=\"TriggeredMessageFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnrecoverableErrorFault\">\n
+        \              <soap:fault name=\"UnrecoverableErrorFault\" use=\"literal\"/>
+        \n            </fault>\n          <fault name=\"DuplicateApiRequestFault\">\n
+        \           <soap:fault name=\"DuplicateApiRequestFault\" use=\"literal\"
+        />\n          </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeTriggerEmail\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeTriggerEmailRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeTriggerEmailResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TriggeredMessageFault\">\n                <soap:fault name=\"TriggeredMessageFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n          <fault name=\"DuplicateApiRequestFault\">\n
+        \           <soap:fault name=\"DuplicateApiRequestFault\" use=\"literal\"
+        />\n          </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeTriggerSMS\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeTriggerSMSRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeTriggerSMSResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TriggeredMessageFault\">\n                <soap:fault name=\"TriggeredMessageFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"DuplicateApiRequestFault\">\n
+        \               <soap:fault name=\"DuplicateApiRequestFault\" use=\"literal\"
+        />\n            </fault>\n        </operation>\n        \n        <operation
+        name=\"triggerCustomEvent\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"triggerCustomEventRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"triggerCustomEventResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"CustomEventFault\">\n                <soap:fault name=\"CustomEventFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n          <fault name=\"DuplicateApiRequestFault\">\n
+        \           <soap:fault name=\"DuplicateApiRequestFault\" use=\"literal\"
+        />\n          </fault>\n        </operation>\n        \n        <operation
+        name=\"launchCampaign\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"launchCampaignRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"launchCampaignResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"CampaignFault\">\n                <soap:fault name=\"CampaignFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"scheduleCampaignLaunch\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"scheduleCampaignLaunchRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"scheduleCampaignLaunchResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"CampaignFault\">\n                <soap:fault name=\"CampaignFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"getLaunchStatus\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"getLaunchStatusRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"getLaunchStatusResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"CampaignFault\">\n                <soap:fault name=\"CampaignFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeListMembers\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeListMembersRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeListMembersResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListFault\">\n                <soap:fault name=\"ListFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"retrieveListMembers\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"retrieveListMembersRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"retrieveListMembersResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListFault\">\n                <soap:fault name=\"ListFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"deleteListMembers\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"deleteListMembersRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"deleteListMembersResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListFault\">\n                <soap:fault name=\"ListFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"deleteProfileExtensionMembers\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"deleteProfileExtensionMembersRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"deleteProfileExtensionMembersResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListExtensionFault\">\n                <soap:fault name=\"ListExtensionFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"createTable\">\n            <soap:operation soapAction=\"\"/>\n            <input
+        name=\"createTableRequest\">\n                <soap:header use=\"literal\"
+        message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"createTableResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"deleteTable\">\n            <soap:operation soapAction=\"\"/>\n            <input
+        name=\"deleteTableRequest\">\n                <soap:header use=\"literal\"
+        message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"deleteTableResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeTableRecords\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeTableRecordsRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeTableRecordsResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"retrieveTableRecords\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"retrieveTableRecordsRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"retrieveTableRecordsResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"deleteTableRecords\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"deleteTableRecordsRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"deleteTableRecordsResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"truncateTable\">\n            <soap:operation soapAction=\"\"/>\n            <input
+        name=\"truncateTableRequest\">\n                <soap:header use=\"literal\"
+        message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"truncateTableResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"createDocument\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"createDocumentRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"createDocumentResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"DocumentFault\">\n                <soap:fault name=\"DocumentFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"deleteDocument\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"deleteDocumentRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"deleteDocumentResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"DocumentFault\">\n                <soap:fault name=\"DocumentFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"setDocumentImages\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"setDocumentImagesRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"setDocumentImagesResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"DocumentFault\">\n                <soap:fault name=\"DocumentFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"getDocumentImages\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"getDocumentImagesRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"getDocumentImagesResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"DocumentFault\">\n                <soap:fault name=\"DocumentFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"setDocumentContent\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"setDocumentContentRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"setDocumentContentResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"DocumentFault\">\n                <soap:fault name=\"DocumentFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"getDocumentContent\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"getDocumentContentRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"getDocumentContentResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"DocumentFault\">\n                <soap:fault name=\"DocumentFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeListMembersRIID\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeListMembersRIIDRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeListMembersRIIDResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListFault\">\n                <soap:fault name=\"ListFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeIntoProfileExtension\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeIntoProfileExtensionRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeIntoProfileExtensionResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListExtensionFault\">\n                <soap:fault name=\"ListExtensionFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"createTableWithPK\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"createTableWithPKRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"createTableWithPKResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"mergeTableRecordsWithPK\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"mergeTableRecordsWithPKRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"mergeTableRecordsWithPKResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"TableFault\">\n                <soap:fault name=\"TableFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n        <operation
+        name=\"retrieveProfileExtensionRecords\">\n            <soap:operation soapAction=\"\"/>\n
+        \           <input name=\"retrieveProfileExtensionRecordsRequest\">\n                <soap:header
+        use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n                <soap:body
+        use=\"literal\"/>\n            </input>\n            <output name=\"retrieveProfileExtensionRecordsResponse\">\n
+        \               <soap:body use=\"literal\"/>\n            </output>\n            <fault
+        name=\"ListExtensionFault\">\n                <soap:fault name=\"ListExtensionFault\"
+        use=\"literal\"/> \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n        </operation>\n        \n         <!-- Content
+        library related operations -->\n        <operation name=\"listContentLibraryFolders\">\n
+        \           <soap:operation soapAction=\"\"/>\n            <input   name=\"listContentLibraryFoldersRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"listContentLibraryFoldersResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"FolderFault\">\n            \t<soap:fault
+        name=\"FolderFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>\n
+        \       \n        <operation name=\"doesContentLibraryFolderExist\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input   name=\"doesContentLibraryFolderExistRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"doesContentLibraryFolderExistResponse\">\n            \t<soap:body
+        use=\"literal\"/>\n            </output>\n            <fault name=\"FolderFault\">\n
+        \           \t<soap:fault name=\"FolderFault\" use=\"literal\"/> \n            </fault>\n
+        \           <fault name=\"UnexpectedErrorFault\">\n            \t<soap:fault
+        name=\"UnexpectedErrorFault\" use=\"literal\"/> \n            </fault>            \n
+        \       </operation>\n        \n        <operation name=\"deleteContentLibraryFolder\">\n
+        \           <soap:operation soapAction=\"\"/>\n            <input   name=\"deleteContentLibraryFolderRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"deleteContentLibraryFolderResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"FolderFault\">\n            \t<soap:fault
+        name=\"FolderFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>\n\n
+        \       <operation name=\"createContentLibraryFolder\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input   name=\"createContentLibraryFolderRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"createContentLibraryFolderResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"FolderFault\">\n            \t<soap:fault
+        name=\"FolderFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>\n
+        \       \n        <operation name=\"createContentLibraryItem\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input   name=\"createContentLibraryItemRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"createContentLibraryItemResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"DocumentFault\">\n            \t<soap:fault
+        name=\"DocumentFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>
+        \      \n \n \t\t<operation name=\"setContentLibraryItem\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input   name=\"setContentLibraryItemRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"setContentLibraryItemResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"DocumentFault\">\n            \t<soap:fault
+        name=\"DocumentFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>
+        \n        \n \t\t<operation name=\"deleteContentLibraryItem\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input   name=\"deleteContentLibraryItemRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"deleteContentLibraryItemResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"DocumentFault\">\n            \t<soap:fault
+        name=\"DocumentFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>
+        \ \n        \n\t\t<operation name=\"getContentLibraryItem\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input   name=\"getContentLibraryItemRequest\">\n
+        \           \t<soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"getContentLibraryItemResponse\">\n            \t<soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"DocumentFault\">\n            \t<soap:fault
+        name=\"DocumentFault\" use=\"literal\"/> \n            </fault>\n            <fault
+        name=\"UnexpectedErrorFault\">\n            \t<soap:fault name=\"UnexpectedErrorFault\"
+        use=\"literal\"/> \n            </fault>            \n        </operation>
+        \ \n        \n        <operation name=\"HaMergeTriggerSms\">\n            <soap:operation
+        soapAction=\"\"/>\n            <input name=\"HaMergeTriggerSmsRequest\">\n
+        \               <soap:header use=\"literal\" message=\"tns:Header\" part=\"SessionHeader\"/>\n
+        \               <soap:body use=\"literal\"/>\n            </input>\n            <output
+        name=\"HaMergeTriggerSmsResponse\">\n                <soap:body use=\"literal\"/>\n
+        \           </output>\n            <fault name=\"TriggeredMessageFault\">\n
+        \               <soap:fault name=\"TriggeredMessageFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnexpectedErrorFault\">\n
+        \              <soap:fault name=\"UnexpectedErrorFault\" use=\"literal\"/>
+        \n            </fault>\n            <fault name=\"UnrecoverableErrorFault\">\n
+        \              <soap:fault name=\"UnrecoverableErrorFault\" use=\"literal\"/>
+        \n            </fault>\n          <fault name=\"DuplicateApiRequestFault\">\n
+        \           <soap:fault name=\"DuplicateApiRequestFault\" use=\"literal\"
+        />\n          </fault>\n        </operation>       \n        <operation name=\"createProfileExtensionTable\">\n
+        \           <soap:operation soapAction=\"\"/>\n            <input name=\"createProfileExtensionTableRequest\">\n
+        \               <soap:header message=\"tns:Header\" part=\"SessionHeader\"
+        use=\"literal\"/>\n                <soap:body use=\"literal\"/>\n            </input>\n
+        \           <output name=\"createProfileExtensionTableResponse\">\n                <soap:body
+        use=\"literal\"/>\n            </output>\n            <fault name=\"ListFault\">\n
+        \               <soap:fault name=\"ListFault\" use=\"literal\"/>\n            </fault>\n
+        \       </operation>\n    </binding>\n    \n    <service name=\"ResponsysWSService\">\n
+        \       <documentation>Responsys Web Services API</documentation>\n        <port
+        binding=\"tns:ResponsysWSSoapBinding\" name=\"ResponsysWS\">\n            <soap:address
+        location=\"https://ws5.responsys.net/webservices/services/ResponsysWSService\"/>\n
+        \       </port>\n    </service>\n</definitions>\n"
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:37 GMT
+- request:
+    method: post
+    uri: https://ws5.responsys.net/webservices/services/ResponsysWSService
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:ws.rsys.com"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:login><tns:username>your_responsys_username</tns:username><tns:password>your_responsys_password</tns:password></tns:login></env:Body></env:Envelope>
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><loginResponse
+        xmlns="urn:ws.rsys.com"><result><sessionId>DEAR_SESSION_ID</sessionId></result></loginResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:37 GMT
+- request:
+    method: post
+    uri: https://ws5.responsys.net/webservices/services/ResponsysWSService
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:ws.rsys.com"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header><sessionHeader><sessionId>DEAR_SESSION_ID</sessionId></sessionHeader></env:Header><env:Body><tns:retrieveListMembers><tns:list><tns:folderName>rspec_tests</tns:folderName><tns:objectName>rspec_list1</tns:objectName></tns:list><tns:queryColumn>EMAIL_ADDRESS</tns:queryColumn><tns:fieldList>EMAIL_PERMISSION_STATUS_</tns:fieldList><tns:idsToRetrieve>user1@email.com</tns:idsToRetrieve></tns:retrieveListMembers></env:Body></env:Envelope>
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><retrieveListMembersResponse
+        xmlns="urn:ws.rsys.com"><result><recordData><fieldNames>EMAIL_PERMISSION_STATUS_</fieldNames><records><fieldValues>I</fieldValues></records></recordData></result></retrieveListMembersResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:37 GMT
+- request:
+    method: post
+    uri: https://ws5.responsys.net/webservices/services/ResponsysWSService
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:ws.rsys.com"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header><sessionHeader><sessionId>DEAR_SESSION_ID</sessionId></sessionHeader></env:Header><env:Body><tns:logout></tns:logout></env:Body></env:Envelope>
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><logoutResponse
+        xmlns="urn:ws.rsys.com"><result>true</result></logoutResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:37 GMT
+- request:
+    method: post
+    uri: https://ws5.responsys.net/webservices/services/ResponsysWSService
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:ws.rsys.com"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:login><tns:username>your_responsys_username</tns:username><tns:password>your_responsys_password</tns:password></tns:login></env:Body></env:Envelope>
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><loginResponse
+        xmlns="urn:ws.rsys.com"><result><sessionId>DEAR_SESSION_ID</sessionId></result></loginResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:37 GMT
+- request:
+    method: post
+    uri: https://ws5.responsys.net/webservices/services/ResponsysWSService
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:ws.rsys.com"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header><sessionHeader><sessionId>DEAR_SESSION_ID</sessionId></sessionHeader></env:Header><env:Body><tns:retrieveListMembers><tns:list><tns:folderName>rspec_tests</tns:folderName><tns:objectName>rspec_list1</tns:objectName></tns:list><tns:queryColumn>EMAIL_ADDRESS</tns:queryColumn><tns:fieldList>EMAIL_PERMISSION_STATUS_</tns:fieldList><tns:idsToRetrieve>user1@email.com</tns:idsToRetrieve></tns:retrieveListMembers></env:Body></env:Envelope>
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><retrieveListMembersResponse
+        xmlns="urn:ws.rsys.com"><result><recordData><fieldNames>EMAIL_PERMISSION_STATUS_</fieldNames><records><fieldValues>I</fieldValues></records></recordData></result></retrieveListMembersResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:38 GMT
+- request:
+    method: post
+    uri: https://ws5.responsys.net/webservices/services/ResponsysWSService
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="urn:ws.rsys.com"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header><sessionHeader><sessionId>DEAR_SESSION_ID</sessionId></sessionHeader></env:Header><env:Body><tns:logout></tns:logout></env:Body></env:Envelope>
+    headers: 
+  response:
+    status:
+      code: 200
+      message: OK
+    headers: 
+    body:
+      encoding: UTF-8
+      string: <?xml version='1.0' encoding='UTF-8'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><logoutResponse
+        xmlns="urn:ws.rsys.com"><result>true</result></logoutResponse></soapenv:Body></soapenv:Envelope>
+    http_version: 
+  recorded_at: Wed, 13 May 2015 16:22:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/member_spec.rb
+++ b/spec/member_spec.rb
@@ -10,33 +10,36 @@ describe Responsys::Member do
   end
 
   context "New member" do
+    before(:each) do
+      @new_user_email = DATA[:users][:new_user4][:EMAIL_ADDRESS]
+      @client = Responsys::Api::Client.new
+      @member = Responsys::Member.new(@new_user_email, nil, @client)
+    end
 
-    xit "should call mergeListMembers" do
+    it "should call mergeListMembers" do
+      expect(@client).to receive(:merge_list_members_riid).with(@list, kind_of(Responsys::Api::Object::RecordData), kind_of(Responsys::Api::Object::ListMergeRule))
+      @member.add_to_list(@list)
     end
 
   end
 
   context "Subscribing" do
 
-    let(:connection) { double "connection" }
     before(:each) do
-      allow(Responsys::Api::Client).to receive(:instance).and_return(connection)
       @member = Responsys::Member.new(@email)
       @query_column = Responsys::Api::Object::QueryColumn.new("EMAIL_ADDRESS")
     end
 
     it "should check the user is present in the list" do
-      expect(@member).to receive(:present_in_list?).with(@list)
+      expect(@member).to receive(:present_in_list?).with(@list, true)
 
       @member.subscribe(@list)
     end
 
     it "should check the user has subscribed" do
-      response_expected = { status: "ok", data: [{ EMAIL_PERMISSION_STATUS_: "I" }] }
-
-      allow(connection).to receive(:retrieve_list_members).with(@list, kind_of(Responsys::Api::Object::QueryColumn), %w(EMAIL_PERMISSION_STATUS_), %W(#{@member.email})).and_return(response_expected)
-
-      expect(@member.subscribed?(@list)).to eq(true)
+      VCR.use_cassette("member/has_subscribed") do
+        expect(@member.subscribed?(@list)).to eq(true)
+      end
     end
 
   end
@@ -123,5 +126,24 @@ describe Responsys::Member do
       end
     end
 
+  end
+
+  context "Disabled GEM" do
+    before(:all) do
+      Responsys.configure { |config| config.settings[:enabled] = false }
+    end
+
+    after(:all) do
+      Responsys.configure { |config| config.settings[:enabled] = true }
+    end
+
+    it "should not make any call" do
+      email = DATA[:users][:user1][:EMAIL_ADDRESS]
+      list = Responsys::Api::Object::InteractObject.new(DATA[:folder],DATA[:lists][:list1][:name])
+      query_column = Responsys::Api::Object::QueryColumn.new("EMAIL_ADDRESS")
+
+      expect_any_instance_of(Responsys::Api::SessionPool).to_not receive(:with)
+      expect(Responsys::Member.new(email).subscribe(list)).to eq("disabled")
+    end
   end
 end

--- a/spec/member_spec.rb
+++ b/spec/member_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper.rb"
-require "responsys/api/client"
 
 describe Responsys::Member do
 
@@ -12,12 +11,11 @@ describe Responsys::Member do
   context "New member" do
     before(:each) do
       @new_user_email = DATA[:users][:new_user4][:EMAIL_ADDRESS]
-      @client = Responsys::Api::Client.new
-      @member = Responsys::Member.new(@new_user_email, nil, @client)
+      @member = Responsys::Member.new(@new_user_email, nil)
     end
 
     it "should call mergeListMembers" do
-      expect(@client).to receive(:merge_list_members_riid).with(@list, kind_of(Responsys::Api::Object::RecordData), kind_of(Responsys::Api::Object::ListMergeRule))
+      expect_any_instance_of(Responsys::Api::Client).to receive(:merge_list_members_riid).with(@list, kind_of(Responsys::Api::Object::RecordData), kind_of(Responsys::Api::Object::ListMergeRule))
       @member.add_to_list(@list)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,8 +35,7 @@ Responsys.configure do |config|
   config.settings = {
     username: CREDENTIALS["username"],
     password: CREDENTIALS["password"],
-    wsdl: CREDENTIALS["wsdl"],
-    element_form_default: :qualified
+    wsdl: CREDENTIALS["wsdl"]
   }
 end
 

--- a/spec/test_data.yml
+++ b/spec/test_data.yml
@@ -15,6 +15,10 @@
     :EMAIL_ADDRESS: user3@email.com
     :EMAIL_PERMISSION_STATUS: O
     :MOBILE_NUMBER: "0000000000"
+  :new_user4: &new_user4
+    :EMAIL_ADDRESS: newuser@email.com
+    :EMAIL_PERMISSION_STATUS: O
+    :MOBILE_NUMBER: "0000000000"
 
 :lists:
   :list1:
@@ -39,7 +43,7 @@
   :pet1:
     :id: 111111111 
     :name: rspec_pet1
-     
+
     :records:
       :user1:
         :MONTHLY_PURCH: 300
@@ -48,5 +52,4 @@
 :supplement_tables:
   :supplement_table1:
     :name: supplement_table1_name
-    :folder_name: supplement_table1_folder  
-              
+    :folder_name: supplement_table1_folder


### PR DESCRIPTION
@12and1studio can you :shipit:?

## Context
Some cleanup in one of the latest version of the GEM removed some very useful savon options handling.
This PR is a refactor of the whole configuration setup + puts back the removed settings.

This is not a breaking change.

## Example
```ruby
Responsys.configuration do |config|
 config.settings = {
    enabled: true, #new
    debug: false,
    sessions: {
      size: 80,
      timeout: 30
    },
    savon_settings: { #new
      ssl_version: :TLSv1,
      element_form_default: :qualified
    }
 }
end
```

## Features
- `enabled`: handles the case where the GEM shouldn't make any call to the API (staging environments, tests). The value can be changed at runtime to enable/disable future calls.
It stops and returns `"disabled"` as soon as a call attempt is made to the API. @12and1studio do you think it's enough/correct?
To do that, either:
  - in a direct call (Responys::Api::*) I return "disabled" in `api_method` if the key `enabled` is false.
  - in the Member class: in the methods that use a client or use other methods that use a client, the content of the method is wrapped and the block is passed to the client. 
If there's a call in a first level method, a `DisabledException` is raised then caught in the client, the flow stops and returns `"disabled"`.
If there's a call in a submethod (present_in_list? called in subscribed?),  a `DisabledException` is raised methods to methods until it's caught in the initial Member's method that made the call. The exception is caught, `"disabled"` is returned.

I can change `"disabled"` by anything else though. Also if you have another cleaner solution, I'd be interested.

- `savon_settings`: the content of the hash is passed to savon. It overrides the GEM default options (i.e ssl_version, element_form_default)