### PR TITLE
only log out if logged in

### DIFF
--- a/lib/responsys/api/client.rb
+++ b/lib/responsys/api/client.rb
@@ -25,7 +25,7 @@ module Responsys
           rescue Exception => e
             Responsys::Helper.format_response_with_errors(e)
           ensure
-            session.logout
+            session.logout if session.logged_in?
           end
         end
       end


### PR DESCRIPTION
A lot of our errors are coming from trying to log out the session, regardless of whether or not the session was initially logged in. This simple fix will only let the session log out if it's already logged in.
