### PR TITLE
Only rescue formattable Savon errors. Let any system errors be raised

### DIFF
--- a/lib/responsys/api/client.rb
+++ b/lib/responsys/api/client.rb
@@ -35,7 +35,7 @@ module Responsys
             else
              response
             end
-          rescue Exception => e
+          rescue Savon::Error => e
             Responsys::Helper.format_response_with_errors(e)
           end
         end


### PR DESCRIPTION
Right now any system errors get caught and passed to the helper, which then tries to call `to_hash` and explodes (for example `Errno::ECONNRESET ` in my case). 

From what I can tell, the only exceptions which respond to `to_hash` here and should be caught and formatted are Savon errors.