### PR TITLE
Improved error handling

### DIFF
--- a/lib/responsys/helper.rb
+++ b/lib/responsys/helper.rb
@@ -64,13 +64,13 @@ module Responsys
 
     def self.format_response_with_errors(error)
       error_response = { status: "failure" }
-
-      if error.to_hash[:fault].has_key?(:detail) and !error.to_hash[:fault][:detail].nil?
-        key = error.to_hash[:fault][:detail].keys[0]
-        error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:detail][key][:exception_code], message: error.to_hash[:fault][:detail][key][:exception_message] }
-        error_response[:error][:trace] = error.to_hash[:fault][:detail][:source] if error.to_hash[:fault][:detail].has_key?(:source)
-      else
-        error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:faultcode], message: error.to_hash[:fault][:faultstring] }
+      case error
+        when Savon::SOAPFault
+          error_response.merge!(format_soap_fault(error))
+        when Savon::HTTPError
+          error_response.merge!(format_http_error(error))
+        else
+          raise error
       end
 
       error_response
@@ -87,5 +87,29 @@ module Responsys
         I18n.t(key, scope: :responsys_api, locale: :en, default: "Responsys - Unknown message '#{key}'")
       end
     end
+
+    private
+
+    def self.format_soap_fault(error)
+      error_response = {}
+      if error.to_hash[:fault].has_key?(:detail) and !error.to_hash[:fault][:detail].nil?
+        key = error.to_hash[:fault][:detail].keys[0]
+        error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:detail][key][:exception_code], message: error.to_hash[:fault][:detail][key][:exception_message] }
+        error_response[:error][:trace] = error.to_hash[:fault][:detail][:source] if error.to_hash[:fault][:detail][:source]
+      else
+        error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:faultcode], message: error.to_hash[:fault][:faultstring] }
+      end
+      error_response
+    end
+
+    def self.format_http_error(error)
+      {
+          error: {
+              http_status_code: error.to_hash[:code],
+              message: error.to_hash[:body],
+          }
+      }
+    end
+
   end
 end

--- a/lib/responsys/helper.rb
+++ b/lib/responsys/helper.rb
@@ -104,10 +104,10 @@ module Responsys
 
       def format_http_error(error)
         {
-            error: {
-                http_status_code: error.to_hash[:code],
-                message: error.to_hash[:body],
-            }
+          error: {
+            http_status_code: error.to_hash[:code],
+            message: error.to_hash[:body],
+          }
         }
       end
     end

--- a/lib/responsys/helper.rb
+++ b/lib/responsys/helper.rb
@@ -88,27 +88,28 @@ module Responsys
       end
     end
 
-    private
-
-    def self.format_soap_fault(error)
-      error_response = {}
-      if error.to_hash[:fault].has_key?(:detail) and !error.to_hash[:fault][:detail].nil?
-        key = error.to_hash[:fault][:detail].keys[0]
-        error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:detail][key][:exception_code], message: error.to_hash[:fault][:detail][key][:exception_message] }
-        error_response[:error][:trace] = error.to_hash[:fault][:detail][:source] if error.to_hash[:fault][:detail][:source]
-      else
-        error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:faultcode], message: error.to_hash[:fault][:faultstring] }
+    class << self
+      private
+      def format_soap_fault(error)
+        error_response = {}
+        if error.to_hash[:fault].has_key?(:detail) and !error.to_hash[:fault][:detail].nil?
+          key = error.to_hash[:fault][:detail].keys[0]
+          error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:detail][key][:exception_code], message: error.to_hash[:fault][:detail][key][:exception_message] }
+          error_response[:error][:trace] = error.to_hash[:fault][:detail][:source] if error.to_hash[:fault][:detail][:source]
+        else
+          error_response[:error] = { http_status_code: error.http.code, code: error.to_hash[:fault][:faultcode], message: error.to_hash[:fault][:faultstring] }
+        end
+        error_response
       end
-      error_response
-    end
 
-    def self.format_http_error(error)
-      {
-          error: {
-              http_status_code: error.to_hash[:code],
-              message: error.to_hash[:body],
-          }
-      }
+      def format_http_error(error)
+        {
+            error: {
+                http_status_code: error.to_hash[:code],
+                message: error.to_hash[:body],
+            }
+        }
+      end
     end
 
   end

--- a/spec/fixtures/soap_fault.xml
+++ b/spec/fixtures/soap_fault.xml
@@ -1,0 +1,8 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Server</faultcode>
+      <faultstring>Fault occurred while processing.</faultstring>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -35,6 +35,40 @@ describe Responsys::Helper do
       expect(Responsys::Helper.get_message(message_key))
         .to eq("Responsys - Unknown message 'member.record_not_found'")
     end
+  end
+
+  describe '#format_response_with_error' do
+    let(:nori) { Nori.new(:strip_namespaces => true, :convert_tags_to => lambda { |tag| tag.snakecase.to_sym }) }
+
+    it 'will format a Savon::SOAPFault response' do
+      fault_body = File.read File.expand_path "../fixtures/soap_fault.xml", __FILE__
+      http_response = HTTPI::Response.new 500, {}, fault_body
+      soap_fault = Savon::SOAPFault.new http_response, nori
+
+      result = Responsys::Helper.format_response_with_errors(soap_fault)
+      expect(result[:status]).to eq "failure"
+      expect(result[:error][:http_status_code]).to eq 500
+      expect(result[:error][:code]).to eq "soap:Server"
+      expect(result[:error][:message]).to eq "Fault occurred while processing."
+    end
+
+    it 'will format a Savon::HTTPError' do
+      http_response = HTTPI::Response.new 503, {}, "Service unavailable"
+      http_error = Savon::HTTPError.new(http_response)
+      result = Responsys::Helper.format_response_with_errors(http_error)
+
+      expect(result[:status]).to eq "failure"
+      expect(result[:error][:http_status_code]).to eq 503
+      expect(result[:error][:message]).to eq "Service unavailable"
+    end
+
+    it 'will re-raise a unformattable Savon error' do
+      unformattable_error = Savon::InvalidResponseError.new
+      expect{
+        Responsys::Helper.format_response_with_errors(unformattable_error)
+      }.to raise_error(Savon::InvalidResponseError)
+    end
 
   end
+
 end


### PR DESCRIPTION
During Responsys maintenance periods Savon will throw http errors rather than SoapFault errors. These don't have a detailed error hash, so when `error.to_hash[:fault].has_key?` is called, it blows up because `error.to_hash[:fault]` is nil. 

This PR adds separate handling for http errors to prevent the explosion and return the http error message. 